### PR TITLE
Implement method body parsing

### DIFF
--- a/src/LibProtodec/CilReader.cs
+++ b/src/LibProtodec/CilReader.cs
@@ -1,0 +1,67 @@
+﻿// Copyright © 2024 Xpl0itR
+// 
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using SystemEx.Memory;
+
+namespace LibProtodec;
+
+public static class CilReader
+{
+    // Temporary AOT incompatible method to fill the dictionary, TODO: replace with a source generator
+    private static readonly Dictionary<int, OpCode> OpCodeLookup =
+        typeof(OpCodes).GetFields(BindingFlags.Public | BindingFlags.Static)
+                       .Select(field => (OpCode)field.GetValue(null)!)
+                       .ToDictionary(opCode => (int)(ushort)opCode.Value);
+
+    public static OpCode ReadCilOpCode(this ref MemoryReader reader, out int operandLength)
+    {
+        byte opCodeByte = reader.ReadByte();
+        int opCodeInt = opCodeByte == OpCodes.Prefix1.Value
+            ? (opCodeByte << 8) | reader.ReadByte()
+            : opCodeByte;
+
+        OpCode opCode = OpCodeLookup[opCodeInt];
+        operandLength = SizeOf(opCode.OperandType);
+
+        return opCode;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int SizeOf(OperandType operandType)
+    {
+        switch (operandType)
+        {
+            case OperandType.ShortInlineBrTarget:
+            case OperandType.ShortInlineI:
+            case OperandType.ShortInlineVar:
+                return 1;
+            case OperandType.InlineVar:
+                return 2;
+            case OperandType.InlineBrTarget:
+            case OperandType.InlineField:
+            case OperandType.InlineI:
+            case OperandType.InlineMethod:
+            case OperandType.InlineSig:
+            case OperandType.InlineString:
+            case OperandType.InlineSwitch:
+            case OperandType.InlineTok:
+            case OperandType.InlineType:
+            case OperandType.ShortInlineR:
+                return 4;
+            case OperandType.InlineI8:
+            case OperandType.InlineR:
+                return 8;
+            case OperandType.InlineNone:
+            default:
+                return 0;
+        }
+    }
+}

--- a/src/LibProtodec/Models/Cil/Clr/ClrMethod.cs
+++ b/src/LibProtodec/Models/Cil/Clr/ClrMethod.cs
@@ -6,6 +6,7 @@
 
 using System.Collections.Generic;
 using System.Reflection;
+using CommunityToolkit.Diagnostics;
 
 namespace LibProtodec.Models.Cil.Clr;
 
@@ -35,4 +36,8 @@ public sealed class ClrMethod(MethodInfo clrMethod) : ClrMember(clrMethod), ICil
                 parameter.ParameterType);
         }
     }
+
+    public byte[] GetMethodBodyILAsByteArray() =>
+        clrMethod.GetMethodBody()?.GetILAsByteArray()
+     ?? ThrowHelper.ThrowNotSupportedException<byte[]>();
 }

--- a/src/LibProtodec/Models/Cil/Clr/ClrModule.cs
+++ b/src/LibProtodec/Models/Cil/Clr/ClrModule.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Concurrent;
+using System.Reflection;
+
+namespace LibProtodec.Models.Cil.Clr;
+
+public sealed class ClrModule : ICilModule
+{
+    private readonly Module _module;
+
+    private ClrModule(Module module) =>
+        _module = module;
+
+    public string ResolveFieldName(int token) =>
+        _module.ResolveField(token).Name;
+
+    public string ResolveMethodName(int token) =>
+        _module.ResolveMethod(token).Name;
+
+
+    private static readonly ConcurrentDictionary<string, ClrModule> ModuleLookup = [];
+
+    public static ICilModule GetOrCreate(Module clrModule) =>
+        ModuleLookup.GetOrAdd(
+            clrModule.FullyQualifiedName,
+            static (_, clrModule) => new ClrModule(clrModule),
+            clrModule);
+}

--- a/src/LibProtodec/Models/Cil/Clr/ClrType.cs
+++ b/src/LibProtodec/Models/Cil/Clr/ClrType.cs
@@ -31,6 +31,10 @@ public sealed class ClrType : ClrMember, ICilType
     public string DeclaringAssemblyName =>
         _clrType.Assembly.FullName!;
 
+    public ICilModule DeclaringModule =>
+        ClrModule.GetOrCreate(
+            _clrType.Module);
+
     public ICilType? BaseType =>
         _clrType.BaseType is null
             ? null

--- a/src/LibProtodec/Models/Cil/ICilMethod.cs
+++ b/src/LibProtodec/Models/Cil/ICilMethod.cs
@@ -23,4 +23,6 @@ public interface ICilMethod
     IList<ICilAttribute> CustomAttributes { get; }
 
     IEnumerable<ICilType> GetParameterTypes();
+
+    byte[] GetMethodBodyILAsByteArray();
 }

--- a/src/LibProtodec/Models/Cil/ICilModule.cs
+++ b/src/LibProtodec/Models/Cil/ICilModule.cs
@@ -1,0 +1,14 @@
+﻿// Copyright © 2024 Xpl0itR
+// 
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+namespace LibProtodec.Models.Cil;
+
+public interface ICilModule
+{
+    string ResolveFieldName(int token);
+
+    string ResolveMethodName(int token);
+}

--- a/src/LibProtodec/Models/Cil/ICilType.cs
+++ b/src/LibProtodec/Models/Cil/ICilType.cs
@@ -14,9 +14,10 @@ public interface ICilType
     string  FullName  { get; }
     string? Namespace { get; }
 
-    string    DeclaringAssemblyName { get; }
-    ICilType? DeclaringType         { get; }
-    ICilType? BaseType              { get; }
+    string     DeclaringAssemblyName { get; }
+    ICilModule DeclaringModule       { get; }
+    ICilType?  DeclaringType         { get; }
+    ICilType?  BaseType              { get; }
 
     bool IsAbstract { get; }
     bool IsClass    { get; }


### PR DESCRIPTION
Parse the MergeFrom, WriteTo and Reflection class constructor method bodies to extract metadata that would otherwise be unable to extract using just class members, such as sint32/64, (s)fixed32/64 and json key names.